### PR TITLE
Fix tuple sorting

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,10 +5,11 @@ version = "0.1.0"
 
 [deps]
 ITensors = "9136182c-28ba-11e9-034c-db9fb085ebd5"
+TupleTools = "9d95972d-f1c8-5527-a6e0-b4b365fa01f6"
 
 [compat]
-julia = "1.6"
 ITensors = "0.3.18"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/correlator_bosonic_recursive.jl
+++ b/src/correlator_bosonic_recursive.jl
@@ -1,3 +1,5 @@
+using TupleTools: TupleTools
+
 # correlator(("A", "B", "C", "D"), [(1, 2, 3, 4), (1, 2, 4, 5), ...])
 function correlator_recursive_compact(
   psi, #::MPS,
@@ -52,7 +54,7 @@ function add_operator(
 
     if counter == N
       R = ((op_ind) < length(psi) ? delta(dag(ln[op_ind]), ln[op_ind]') : ITensor(1.0)) #create right system
-      C[tuple([element[k] for k in [findall(x -> x == j, indices)[1] for j in sort(indices)]]...)] = inner(
+      C[tuple([element[k] for k in [findall(x -> x == j, indices)[1] for j in TupleTools.sort(indices)]]...)] = inner(
         dag(L), R
       )
     else
@@ -105,7 +107,7 @@ function add_operator_repeat(
 
     if counter == N
       R = ((op_ind) < length(psi) ? delta(dag(ln[op_ind]), ln[op_ind]') : ITensor(1.0)) #create right system
-      C[tuple([element[k] for k in [findall(x -> x == j, indices)[1] for j in sort(indices)]]...)] = inner(
+      C[tuple([element[k] for k in [findall(x -> x == j, indices)[1] for j in TupleTools.sort(indices)]]...)] = inner(
         dag(L), R
       )
     else
@@ -189,7 +191,7 @@ function add_operator_fermi(
 
     if counter == N
       R = ((op_ind) < length(psi) ? delta(dag(ln[op_ind]), ln[op_ind]') : ITensor(1.0)) #create right system
-      C[tuple([element[k] for k in [findall(x -> x == j, indices)[1] for j in sort(indices)]]...)] = inner(
+      C[tuple([element[k] for k in [findall(x -> x == j, indices)[1] for j in TupleTools.sort(indices)]]...)] = inner(
         dag(L), R
       )
       #push!(C, tuple([element[k] for k in [findall(x->x==j,indices)[1] for j in sort(indices)]]...) => inner(dag(L), R))


### PR DESCRIPTION
Currently the example in the `README.md` fails with
```julia
julia> c = correlator(psi, ("Sz", "Sz", "Sz", "Sz"), [(1, 3, 4, 5), (2, 3, 4, 5), (3, 4, 5, 10)])
ERROR: MethodError: no method matching sort(::NTuple{4, Int64})

Closest candidates are:
  sort(::AbstractUnitRange)
   @ Base range.jl:1410
  sort(::AbstractRange)
   @ Base range.jl:1413
  sort(::Dictionaries.AbstractIndices{I}; kwargs...) where I
   @ Dictionaries ~/.julia/packages/Dictionaries/7aBxp/src/AbstractIndices.jl:376
  ...
```
This commit fixes the sorting of the tuple indices and things now run 